### PR TITLE
Change local build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ bundle install && bundle exec rake init
 Fire up Jekyll:
 
 ```
-jekyll serve
+bundle exec jekyll serve
 ```
+
+
 
 Open the site at [http://127.0.0.1:4000/](http://127.0.0.1:4000/)


### PR DESCRIPTION
The `jekyll serve` command never works for me; can we change the command to `bundle exec jekyll serve` or at least make a comment.
