### PR TITLE
Home page, side nav items and README

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Digital Transformation Agency
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -41,13 +41,23 @@ bundle exec jekyll serve
 
 Open the site at [http://127.0.0.1:4000/](http://127.0.0.1:4000/)
 
-### Updating content from UI Kit
+### Updating content from UI-Kit
 
-This guide includes the [UI Kit](https://github.com/AusDTO/gov-au-ui-kit) as a [git submodule](https://www.kernel.org/pub/software/scm/git/docs/user-manual.html#submodules). There are two Rake tasks available for interacting with UI Kit: `uikit:install` sets up the submodule and installs UI Kit's npm dependencies and `uikit:json_comments` which pulls out the KSS comments from UI Kit's SASS files and adds it to the `_data` directory for Jekyll to use.
+This guide includes the [UI-Kit](https://github.com/AusDTO/gov-au-ui-kit) as a [git submodule](https://www.kernel.org/pub/software/scm/git/docs/user-manual.html#submodules) to `_assets/vendor/dto-ui-kit`.
+
+```
+├── _assets
+│   └── vendor
+│       └── dto-ui-kit
+```
+
+There are two Rake tasks available for interacting with UI-Kit: `uikit:install` sets up the submodule and installs UI-Kit's npm dependencies. `uikit:json_comments` pulls out the KSS comments from UI-Kit's SASS files and adds it to the `_data` directory for Jekyll to use. It also copies UI-Kit's HTML template files into the `_includes` directory.
 
 ```
 ├── _data
 │   └── data-sections.json
+├── _includes
+│   └── templates
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ bundle exec jekyll serve
 
 Open the site at [http://127.0.0.1:4000/](http://127.0.0.1:4000/)
 
+### Updating content from UI Kit
+
+This guide includes the [UI Kit](https://github.com/AusDTO/gov-au-ui-kit) as a [git submodule](https://www.kernel.org/pub/software/scm/git/docs/user-manual.html#submodules). There are two Rake tasks available for interacting with UI Kit: `uikit:install` sets up the submodule and installs UI Kit's npm dependencies and `uikit:json_comments` which pulls out the KSS comments from UI Kit's SASS files and adds it to the `_data` directory for Jekyll to use.
+
+```
+├── _data
+│   └── data-sections.json
+```
+
 ## Contributing
 
 Open an issue first to discuss potential changes/additions. We encourage you to read our [Contributor Code of Conduct](https://github.com/AusDTO/gov-au-ui-kit/blob/master/code_of_conduct.md). By ensuring that all contributors follow this guide we can maintain an inclusive and friendly community.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ How to use the UI-Kit CSS framework to build accessible and usable sites.
 
 ## Table of contents
 1. [Development](#development)
+1. [Contributing](#contributing)
 1. [Copyright & license](#copyright--license)
 
 ## Development
@@ -39,6 +40,10 @@ bundle exec jekyll serve
 ```
 
 Open the site at [http://127.0.0.1:4000/](http://127.0.0.1:4000/)
+
+## Contributing
+
+Open an issue first to discuss potential changes/additions. We encourage you to read our [Contributor Code of Conduct](https://github.com/AusDTO/gov-au-ui-kit/blob/master/code_of_conduct.md). By ensuring that all contributors follow this guide we can maintain an inclusive and friendly community.
 
 ## Copyright & license
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ How to use the UI-Kit CSS framework to build accessible and usable sites.
 
 ## Development
 
-Platform & dependencies:
+Development dependencies:
+
 * Ruby (= 2.3.1)
 * Jekyll (= 3.2.1)
 * Jekyll Assets (= 2.2.8)
+* Rouge (~> 1.7)
 
 Clone the repo:
 
@@ -15,7 +17,7 @@ Clone the repo:
 git clone https://github.com/AusDTO/dto-design-guide.git
 ```
 
-Install dependencies and setup project:
+Install dependencies and set up project:
 
 ```
 cd dto-design-guide

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Fire up Jekyll:
 bundle exec jekyll serve
 ```
 
-
-
 Open the site at [http://127.0.0.1:4000/](http://127.0.0.1:4000/)
+
+## Copyright & license
+
+Copyright Digital Transformation Agency. Licensed under the [MIT license](https://github.com/AusDTO/dto-design-guide/blob/master/LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 How to use the UI-Kit CSS framework to build accessible and usable sites.
 
+---
+
+## Table of contents
+1. [Development](#development)
+1. [Copyright & license](#copyright--license)
+
 ## Development
 
 Development dependencies:

--- a/_components/iconography.md
+++ b/_components/iconography.md
@@ -1,6 +1,0 @@
----
-layout: default
-title: Forms
----
-
-blah

--- a/_config.yml
+++ b/_config.yml
@@ -28,15 +28,3 @@ page_gen:
     template: "section"
     name: "header"
     dir: "sections"
-
-collections:
-  foundations:
-    output: true
-    title: "Foundations"
-    abstract: "Foundations are important to avoid wobbly scaffolding."
-  components:
-    title: "Components"
-    output: true
-  patterns:
-    title: "Patterns"
-    output: true

--- a/_foundations/iconography.md
+++ b/_foundations/iconography.md
@@ -1,6 +1,0 @@
----
-layout: default
-title: Iconography
----
-
-foobar barfoo

--- a/_foundations/index.md
+++ b/_foundations/index.md
@@ -1,6 +1,0 @@
----
-layout: collection-index
-title: Foundations overview
----
-
-I’m another lonely, empty page. :sadface:

--- a/_foundations/typography.md
+++ b/_foundations/typography.md
@@ -1,6 +1,0 @@
----
-layout: default
-title: Typography
----
-
-I will be the typography page, within the *Foundations* collection.

--- a/_includes/site_nav.html
+++ b/_includes/site_nav.html
@@ -11,33 +11,25 @@
     </li>
     {% endfor %}
 
-    <li>
-      <a href="/styleguide.html">Styleguide</a>
+    {% for collection in site.collections %}
+    {% capture label %}{{ collection.label }}{% endcapture %}
 
-      <ul class="collections">
-      {% for collection in site.collections %}
-      {% capture label %}{{ collection.label }}{% endcapture %}
+      {% if label == "posts" %}
+        {% continue %}
+      {% endif %}
 
-        {% if label == "posts" %}
-          {% continue %}
-        {% endif %}
+      <li>
+        <a href="/{{ label }}">{{ label | capitalize }}</a>
+      </li>
+    {% endfor %}
 
-        <li>
-          <a href="/{{ label }}">{{ label | capitalize }}</a>
-        </li>
-      {% endfor %}
-      </ul>
+    {% for section in site.data.data-sections %}
+      {% unless section.referenceNumber contains '.' %}
+      <li>
+        <a href="/sections/{{ section.header | slugify }}.html">{{ section.header }}</a>
+      </li>
+      {% endunless %}
+    {% endfor %}
 
-      <ul>
-      {% for section in site.data.data-sections %}
-        {% unless section.referenceNumber contains '.' %}
-        <li>
-          <a href="/sections/{{ section.header | slugify }}.html">{{ section.header }}</a>
-        </li>
-        {% endunless %}
-      {% endfor %}
-      </ul>
-      
-    </li>
   </ul>
 </nav>

--- a/getting_started.md
+++ b/getting_started.md
@@ -1,6 +1,0 @@
----
-layout: page
-title: Getting started with UI Kit
----
-
-# Getting started

--- a/index.md
+++ b/index.md
@@ -2,4 +2,109 @@
 layout: default
 ---
 
-I’m a lonely, empty page. :(
+# Getting started
+
+## What is this?
+
+UI-Kit is 2 things:
+
+1. a draft design guide to build an accessible standardised look and feel for GOV.AU projects: [gov-au-ui-kit.apps.staging.digital.gov.au](http://gov-au-ui-kit.apps.staging.digital.gov.au/)
+ common-use [HTML templates](/examples)
+2. a lean and frugal CSS & JS framework (found in `assets/`) that you can
+include in your project:
+
+**Link to precompiled minified files**
+
+```
+<link rel="stylesheet" type="text/css" href="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.css"/>
+<script type="text/javascript" src="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.js"></script>
+```
+
+GOV.AU UI-Kit is currently in early draft release. You can help us build it by [contributing](CONTRIBUTING.md).
+
+The [/docs/](https://github.com/AusDTO/gov-au-ui-kit/tree/develop/docs) folder contains draft documentation on experimental work. For example, how to install UI-Kit for use with `webpack`.
+
+### Features
+
+- <a href="https://necolas.github.io/normalize.css/" rel="external">Normalize</a>.
+- <a href="http://bourbon.io/" rel="external">Bourbon</a>, version 4.2.7.
+- <a href="http://neat.bourbon.io/" rel="external">Neat</a>, and settings for a grid framework with some good defaults.
+- Basic styling for content with some good typographic coverage.
+- Basic styling for UI elements (eg `input`, `label`, etc).
+
+For a full list of features see the [CHANGELOG](CHANGELOG.md).
+
+### Accessibility
+
+The framework is built on a solid accessible HTML foundation. We follow a philosophy of <a href="https://en.wikipedia.org/wiki/Progressive_enhancement" rel="external">progressive enhancement</a> over <a href="https://en.wikipedia.org/wiki/Fault_tolerance" rel="external">graceful degradation</a> to produce accessible components by default.
+
+UI Kit aims to be WCAG2 AA compliant, and AAA where possible.
+
+We use automated testing:
+- WCAG 2.0 criteria using <a href="http://squizlabs.github.io/HTML_CodeSniffer/" rel="external">HTML_CodeSniffer</a>
+- HTML validation using <a href="http://validator.github.io/validator/" rel="external">Nu HTML Checker</a>.
+
+We are working on:
+- manual evaluation using <a href="http://wave.webaim.org/" rel="external">Wave by WebAIM</a>
+- manual checking of page structure, content and keyboard navigation
+- testing with users and assistive technologies
+- an audit.
+
+### Browser support
+Read [cross browser and device support](BROWSER-SUPPORT.md) table.
+
+The kit uses a [conditional styling mixin for specific versions of IE](https://github.com/AusDTO/gov-au-ui-kit/tree/develop/assets/sass/_ie.scss). Use this when extending the kit.
+
+We are working on:
+
+- automated browser testing as part of our build process
+- manual testing of all CSS, JS and markup
+- documenting browser support for each component.
+
+## What this isn't
+
+This is not yet a complete design or design system. This is the starting point that will develop with your help.
+
+## Who is this for?
+
+Teams building Australian Government sites. This was designed for GOV.AU teams, but we welcome use outside of federal government.
+
+## How is this related to the Digital Service Standard?
+
+The <a href="https://www.dto.gov.au/standard/" rel="external">Digital Service Standard</a> requires teams to <a href="https://www.dto.gov.au/standard/6-consistent-and-responsive/" rel="external">build services using common design patterns</a>. This is draft work on the framework and guidance that will eventually become the design patterns for digital content.
+
+You should use this with the <a href="http://content-style-guide.apps.staging.digital.gov.au/" rel="external">draft <strong>Content Style Guide</strong></a> for Digital Transformation Office projects.
+
+## Make GOV.AU UI-Kit better
+
+- Contribute to our <a href="https://github.com/AusDTO/gov-au-ui-kit/issues" rel="external">GitHub issue register</a> by logging new issues and joining the discussion.
+- Contribute to this repository. Please see [CONTRIBUTING.md](CONTRIBUTING.md), [Contributor Code of Conduct](code_of_conduct.md) and [our code Conventions](conventions.md), (also see <a href="http://getbem.com/" rel="external">Block Element Modifier</a>), first.
+- Contact us via the DTO slack in `#guides-uikit`.
+
+## Project goal
+
+This framework is in active development.
+
+Goal: build a lean and frugal CSS/SCSS framework to make building GOV.AU easier. It should:
+
+- provide base consistency
+- allow for easier rapid prototyping directly in the browser
+- should not get in the way of customised design needs.
+
+### Releases
+
+See [RELEASING.md](RELEASING.md) and [CHANGELOG.md](CHANGELOG.md).
+
+We aim to provide stable, usable releases at the end of each sprint.
+
+### Deprecation
+
+We are wary about breaking changes. We will work to ensure we will gracefully deprecate any changes that cause things to break.
+
+### Installer/wrapper
+
+We may create an installer wrapper (likely node-based), or release via git submodules.
+
+## Copyright & license
+
+Copyright Digital Transformation Office. <a href="(https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE" rel="external license">Licensed under the MIT license</a>.

--- a/styleguide.md
+++ b/styleguide.md
@@ -1,5 +1,0 @@
----
-layout: default
----
-
-# Landing page for the style guide


### PR DESCRIPTION
I've made a few changes to the Design Guide to make it ready to replace [the current guide embedded in UI Kit](https://gov-au-ui-kit.apps.staging.digital.gov.au):

* The README now contains an up to date dependencies list, info about the UI-Kit submodule as well as copyright, license & contributing details
* The home page now contains the same content as the [UI Kit README](https://github.com/AusDTO/gov-au-ui-kit/blob/develop/README.md) (minus any content that didn't make sense out of context).
* The side nav only contains links to the Home page and to each style guide section