### PR TITLE
QA feature branches

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,7 +4,7 @@
   <section class="govau--header">
     <div class="wrapper">
       <div class="govau--logo">
-        <a href="/" class="logo">{{ site.title }}</a> <span class="badge--default">beta</span>
+        <a href="{{ site.baseurl }}/" class="logo">{{ site.title }}</a> <span class="badge--default">beta</span>
       </div>
       {% include feedback.html %}
     </div>

--- a/_includes/local_nav.html
+++ b/_includes/local_nav.html
@@ -18,7 +18,7 @@
       {% endif %}
 
       <li>
-        <a href="{{ site.baseurl }}/{{ label }}">{{ label | capitalize }}</a>
+        <a href="{{ site.baseurl }}/{{ label }}/index.html">{{ label | capitalize }}</a>
       </li>
     {% endfor %}
 

--- a/_includes/local_nav.html
+++ b/_includes/local_nav.html
@@ -1,13 +1,13 @@
 <nav id="nav" class="local-nav" aria-label="main navigation">
   <ul>
     <li>
-      <a href="/">Home</a>
+      <a href="{{ site.baseurl }}/">Home</a>
     </li>
 
     {% assign pages = site.pages | where: "layout", "page" %}
     {% for page in pages %}
     <li>
-      <a href="{{ page.url }}">{{ page.title }}</a>
+      <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
     </li>
     {% endfor %}
 
@@ -18,7 +18,7 @@
       {% endif %}
 
       <li>
-        <a href="/{{ label }}">{{ label | capitalize }}</a>
+        <a href="{{ site.baseurl }}/{{ label }}">{{ label | capitalize }}</a>
       </li>
     {% endfor %}
 
@@ -28,7 +28,7 @@
         {% unless section.referenceNumber contains '.' %}
           {% unless section.collection %}
           <li>
-            <a href="/sections/{{ section.header | slugify }}.html">{{ section.header }}</a>
+            <a href="{{ site.baseurl }}/sections/{{ section.header | slugify }}.html">{{ section.header }}</a>
           </li>
           {% endunless %}
         {% endunless %}

--- a/_layouts/collections/overview.html
+++ b/_layouts/collections/overview.html
@@ -15,7 +15,7 @@ layout: default
     {% for doc in collection.docs %}
       {% unless doc.layout == "collections/overview" %}
   <li>
-    <a href="{{ doc.url }}">{{ doc.title }}</a>
+    <a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a>
   </li>
       {% endunless %}
     {% endfor %}

--- a/_layouts/section.html
+++ b/_layouts/section.html
@@ -22,7 +22,7 @@ layout: default
       {% if section_title == section.header %}
         {% for child in section.children %}
 
-      <li><a href="/sections/{{ section.header | slugify }}.html#{{ child.header | slugify }}">{{ child.header }}</a></li>
+      <li><a href="{{ site.baseurl }}/sections/{{ section.header | slugify }}.html#{{ child.header | slugify }}">{{ child.header }}</a></li>
 
         {% endfor %}
       {% endif %}

--- a/bin/cibuild.sh
+++ b/bin/cibuild.sh
@@ -17,3 +17,6 @@ bundle exec rake init
 
 # Run Jekyll
 bundle exec jekyll build
+
+# Set up the site in $CIRCLE_ARTIFACTS
+bundle exec jekyll build --destination $CIRCLE_ARTIFACTS/site --baseurl /0/$CIRCLE_ARTIFACTS/site

--- a/circle.yml
+++ b/circle.yml
@@ -16,3 +16,8 @@ deployment:
     branch: master
     commands:
       - ./bin/cideploy.sh
+
+# get relevant circle artifacts posted as links to github pull requests
+notify:
+  webhooks:
+    - url: https://qa-ice.apps.staging.digital.gov.au


### PR DESCRIPTION
QA fire spins up an environment in cloud foundry, including backing databases etc, to enable QA of feature branches but it does not work for projects that require pre-building (eg jekyll projects). On the other hand, CircleCI supports serving static assets using the $CIRCLE_ARTIFACTS directory. This was an experiment to see if circle would be sufficient for your specific situation.

## Pros

* no need to deal with cloud foundry at all
* don't need to know when to delete things
* don't need to worry about quotas etc
* faster than using cloud foundry

## Cons

* The site needs to support having an arbitrary url prefix (ie jekyll `baseurl`)
* The circle web server does not automatically direct '/foo/' to '/foo/index.html'. This is something of a pain but maybe it's enough to check the basic things. (see https://discuss.circleci.com/t/circle-artifacts-com-not-using-index-html/320)

PS. The notify thing to qa-ice is just a tiny script I wrote to post the link the the circle artifact back onto the pull request.