### PR TITLE
Color changes, space changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ How to use the UI-Kit CSS framework to build accessible and usable sites.
 Development dependencies:
 
 * Ruby (= 2.3.1)
-* Jekyll (= 3.2.1)
-* Jekyll Assets (= 2.2.8)
-* Rouge (~> 1.7)
+* Node & npm (+= 5.10)
 
 Clone the repo:
 

--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -9,7 +9,7 @@ table {
 // Custom styling for the rendered example and code blocks.
 
 .guide-example {
-  border: solid 7px $non-white;
+  border: solid 7px darken($non-white, 5%);
   border-radius: $base-border-radius;
   margin: $base-spacing 0;
   padding-top: 0;
@@ -18,7 +18,7 @@ table {
     @extend .content-full-width;
 
     margin: 0;
-    background-color: $non-white;
+    background-color: darken($non-white, 5%);
     padding: $small-spacing $medium-spacing;
 
     span {
@@ -58,12 +58,12 @@ table {
     padding: $medium-spacing ($medium-spacing + $small-spacing);
     border-bottom-left-radius: $base-border-radius;
     border-bottom-right-radius: $base-border-radius;
-    border-top: 1px solid lighten($navy, 7%);
-    background-color: $navy;
+    border-top: solid 7px darken($non-white, 5%);
+    background-color: transparent;
     font-size: rem(15);
     color: $non-white;
 
-    @include link-colours($link-inverted-colour, $link-inverted-colour, $controls-bg-colour);
+    @include link-colours($non-black, $light-aqua, $non-black);
   }
 }
 
@@ -92,6 +92,20 @@ table {
   }
 }
 
+// Custom styling for the accordion
+
+details,
+.accordion {
+  border-right: 1px solid $border-colour;
+  border-left: 1px solid $border-colour;
+}
+
+// Custom styling for abstract
+
+p.abstract {
+  border-bottom: none;
+  padding-bottom: 0;
+}
 
 // Custom styling for the Colours section, specifically for the palette.
 

--- a/_includes/guide_example.html
+++ b/_includes/guide_example.html
@@ -20,7 +20,7 @@
   <cite class="guide-example--cite">
     Stylesheet source on GitHub:
     <a href="
-      {{ site.github_url }}/tree/master/{{ include.sourceFile }}#L{{ include.sourceLine }}"
-      rel="external"><code>{{ include.sourceFile }}</code></a>, line {{ include.sourceLine }}
+      {{ site.github_url }}/tree/master/{{ include.sourceFile }}"
+      rel="external"><code>{{ include.sourceFile }}</code></a>
   </cite>
 </div>


### PR DESCRIPTION
-  [x] We also need to change the blue below the code block.
-  [x] Can we make the left and right borders visible on accordions? Kinda looks weird with just the bottom visible.
-  [x] The `abstract` class gives a bottom border. I've use an inline override (bad me) in the branch - can we discuss removing it completely from UI-Kit? I can't see a good semantic reason for always having a visible bottom border on `abstract` elements.
-  [x] Fix contrast of border on examples
- [x] Reduce spacing between principle statement and `In this section` menu.
- [x] Reduce spacing between principle statement and Examples.