### PR TITLE
Feature/39 t8y refactor cleanup

### DIFF
--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -1,4 +1,4 @@
-$lighter-grey:    lighten($grey, 40%);
+$lighter-grey:    lighten($grey, 48%);
 
 $spacing-double: ($base-spacing * 2);
 $spacing-three-quarter: ($medium-spacing + $small-spacing);
@@ -24,6 +24,40 @@ table {
 header[role='banner'] {
   .feedback {
     @include button-colours(transparent, $button-bg-colour--hover, $button-bg-colour--active, $button-bg-colour--hover, $button-text-colour);
+  }
+}
+
+main {
+  header {
+    h1 {
+      .guide-title {
+        display: block;
+        font-size: 0.5em;
+        color: #6f777b;
+      }
+    }
+  }
+  // Custom styling for sidebar
+  //
+  // We are hard-coding these % values from Neat results of the this grid setup.
+  // We are doing this to get the sidebar floated to the left, w/ the right.
+  // of margins.
+  //
+  // We should be able to remove this in the future when UI-Kit provides this.
+
+  .sidebar {
+    float: left;
+
+    @include media($tablet) {
+      margin-left: 0;
+      margin-right: 2.74614%;
+    }
+
+    @include media($desktop) {
+      float: left;
+      margin-left: 0;
+      margin-right: 2.04556%;
+    }
   }
 }
 
@@ -135,30 +169,6 @@ p.abstract {
 
 .guide-example--code {
   padding-bottom: 1.2em; // not base-spacing?
-}
-
-
-// Custom styling for sidebar
-//
-// We are hard-coding these % values from Neat results of the this grid setup.
-// We are doing this to get the sidebar floated to the left, w/ the right.
-// of margins.
-//
-// We should be able to remove this in the future when UI-Kit provides this.
-
-main .sidebar {
-  float: left;
-
-  @include media($tablet) {
-    margin-left: 0;
-    margin-right: 2.74614%;
-  }
-
-  @include media($desktop) {
-    float: left;
-    margin-left: 0;
-    margin-right: 2.04556%;
-  }
 }
 
 // Custom styling for the Colours section, specifically for the palette.

--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -1,3 +1,7 @@
+$lighter-grey:    lighten($grey, 40%);
+
+$guide-eg-border-width: 7px;
+
 %scrolling-example {
   width: 100%;
 }
@@ -19,8 +23,9 @@ header[role='banner'] {
 
 // Custom styling for the rendered example and code blocks.
 
+// Extract the repeating bits plz
 .guide-example {
-  border: solid 7px darken($non-white, 5%);
+  border: solid $guide-eg-border-width: $lighter-grey;
   border-radius: $base-border-radius;
   margin: $base-spacing 0;
   padding-top: 0;
@@ -29,7 +34,7 @@ header[role='banner'] {
     @extend .content-full-width;
 
     margin: 0;
-    background-color: darken($non-white, 5%);
+    background-color: $lighter-grey;
     padding: $small-spacing $medium-spacing;
 
     span {
@@ -69,7 +74,7 @@ header[role='banner'] {
     padding: $medium-spacing ($medium-spacing + $small-spacing);
     border-bottom-left-radius: $base-border-radius;
     border-bottom-right-radius: $base-border-radius;
-    border-top: solid 7px darken($non-white, 5%);
+    border-top: solid $guide-eg-border-width $lighter-grey;
     background-color: transparent;
     font-size: rem(15);
     color: $non-white;
@@ -112,7 +117,8 @@ details,
 }
 
 // Custom styling for abstract
-
+//
+// This seems defunkt?
 p.abstract {
   border-bottom: none;
   padding-bottom: 0;
@@ -122,11 +128,17 @@ p.abstract {
 // Custom styling for code examples
 
 .guide-example--code {
-  padding-bottom: 1.2em;
+  padding-bottom: 1.2em; // not base-spacing?
 }
 
 
 // Custom styling for sidebar
+//
+// We are hard-coding these % values from Neat results of the this grid setup.
+// We are doing this to get the sidebar floated to the left, w/ the right.
+// of margins.
+//
+// We should be able to remove this in the future when UI-Kit provides this.
 
 main .sidebar {
   float: left;
@@ -194,6 +206,7 @@ main .sidebar {
   }
 }
 
+// Maybe we can simplify this stuff into a mixin?
 .bg-non-black {
   background-color: $non-black;
   color: $non-white;

--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -1,5 +1,11 @@
 $lighter-grey:    lighten($grey, 40%);
 
+$spacing-double: ($base-spacing * 2);
+$spacing-three-quarter: ($medium-spacing + $small-spacing);
+$spacing-half: $medium-spacing;
+$spacing-quarter: $small-spacing;
+$spacing-eighth: $tiny-spacing;
+
 $guide-eg-border-width: 7px;
 
 %scrolling-example {
@@ -25,7 +31,7 @@ header[role='banner'] {
 
 // Extract the repeating bits plz
 .guide-example {
-  border: solid $guide-eg-border-width: $lighter-grey;
+  border: solid $guide-eg-border-width $lighter-grey;
   border-radius: $base-border-radius;
   margin: $base-spacing 0;
   padding-top: 0;

--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -17,13 +17,6 @@ header[role='banner'] {
   }
 }
 
-// Custom styling for the site nav active state
-
-.site-nav__wrapper li a.is-active {
-  border-color: $site-nav-border-colour--hover;
-  color: $link-colour;
-}
-
 // Custom styling for the rendered example and code blocks.
 
 .guide-example {

--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -33,7 +33,7 @@ main {
       .guide-title {
         display: block;
         font-size: 0.5em;
-        color: #6f777b;
+        color: $grey;
       }
     }
   }

--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -11,8 +11,9 @@
             <li><a href="https://www.dto.gov.au/privacy-statement/" rel="external">Privacy Statement</a></li>
           </ul>
         </nav>
-        <p>© Commonwealth of Australia <br>
+        <p>&copy; Commonwealth of Australia <br>
         <a href="{{ site.github_url }}/blob/master/LICENSE.md" rel="external license">Licensed under the MIT License.</a></p>
+        <p><a href="#">Back to top &uarr;</a></p>
       </div>
     </section>
   </div>

--- a/_layouts/collections/item.liquid
+++ b/_layouts/collections/item.liquid
@@ -6,8 +6,9 @@ layout: default
   Header
 {% endcomment %}
 <header>
-  <h1><span style="font-size:0.5em; color:#6f777b;">DTA Design Guide</span><br />
-  <span>{{ page.title }}</span></h1>
+  <h1><span class="guide-title">DTA Design Guide</span>
+   {{ page.title }}
+ </h1>
 
 
   {% comment %}

--- a/_layouts/collections/overview.liquid
+++ b/_layouts/collections/overview.liquid
@@ -8,19 +8,3 @@ layout: default
 </header>
 
 {{ content }}
-
-<ul>
-{% for collection in site.collections %}
-  {% if collection.label == page.collection %}
-
-    {% for doc in collection.docs %}
-      {% unless doc.layout == "collections/overview" %}
-  <li>
-    <a href="{{ doc.url }}">{{ doc.title }}</a>
-  </li>
-      {% endunless %}
-    {% endfor %}
-    {% break %}
-  {% endif %}
-{% endfor %}
-</ul>

--- a/_layouts/collections/overview.liquid
+++ b/_layouts/collections/overview.liquid
@@ -3,8 +3,9 @@ layout: default
 ---
 
 <header>
-  <h1><span style="font-size:0.5em; color:#6f777b;">DTA Design Guide</span><br />
-  <span>{{ page.title }}</span></h1>
+  <h1><span class="guide-title">DTA Design Guide</span>
+   {{ page.title }}
+ </h1>
 </header>
 
 {{ content }}


### PR DESCRIPTION
Mostly minor edits, catering for some of the items from the checklist in #39.

- Removes duplicate list of section child items (made redundant by local-nav) in collection overview/index pages.
- Moves any inline CSS styling from Liquid templates into the design-guide.scss partial (eg the page h1 span styling).
- Adds a back to top link into the page footer template.
- Minor cleanups of design-guide.scss + comment markers for further cleanups.