### PR TITLE
Feature: Adds anchors for section h2s and with links to their ID, and a pilcrow :hover

### DIFF
--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -64,22 +64,33 @@ body > main {
     }
   }
 
-  h2[id]:hover {
+  // This gives us a little pilcrow (trad. paragraph marker) to the left of any
+  // h2s that have an ID and contain an anchor with the .headline-slug-link
+  // class on hover.
+  //
+  // This feature is used to give users a visual hover effect and hint that the
+  // heading has an ID and URL that can be copied to provide a link directly to
+  // this heading on the page.
+  //
+  // Might want to consider moving this into UI-Kit in the future.
+  h2[id] {
     .headline-slug-link {
       border-bottom: none;
-      padding: 0 12px 6px 3px;
-      border-radius: $base-border-radius;
-
-      &:before {
-        content: '\00B6'; // pilcrow
-        font-size: $smaller-font-size;
-        margin-left: $tiny-spacing;
-        color: $green;
-      }
+      position: relative;
 
       &:hover {
         border-bottom: none;
-        background-color: $light-green;
+        background-color: $background-colour;
+
+        &:after {
+          content: '\00B6'; // pilcrow character
+          position: absolute;
+          width: rem(24);
+          left: -(rem(24));
+          top: 0.5em;
+          font-size: $smaller-font-size;
+          color: $grey;
+        }
       }
     }
   }

--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -52,7 +52,7 @@ header[role='banner'] {
   }
 }
 
-main {
+body > main {
   header {
     h1 {
       .guide-title {
@@ -63,6 +63,27 @@ main {
       }
     }
   }
+
+  h2[id]:hover {
+    .headline-slug-link {
+      border-bottom: none;
+      padding: 0 12px 6px 3px;
+      border-radius: $base-border-radius;
+
+      &:before {
+        content: '\00B6'; // pilcrow
+        font-size: $smaller-font-size;
+        margin-left: $tiny-spacing;
+        color: $green;
+      }
+
+      &:hover {
+        border-bottom: none;
+        background-color: $light-green;
+      }
+    }
+  }
+
   // Custom styling for sidebar
   //
   // We are hard-coding these % values from Neat results of the this grid setup.

--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -52,7 +52,7 @@ header[role='banner'] {
   }
 }
 
-body > main {
+main {
   header {
     h1 {
       .guide-title {

--- a/_layouts/collections/item.liquid
+++ b/_layouts/collections/item.liquid
@@ -64,7 +64,9 @@ layout: default
     {% assign headline = page_section.first[ 1 ] %}
 
     {% unless headlines == 1 %}
-      <h2 id="{{ headline | slugify }}">{{ headline }}</h2>
+      <h2 id="{{ headline | slugify }}">{{ headline }}
+        <a href="{{ page.url }}/#{{ headline | slugify }}" class="headline-slug-link"></a>
+      </h2>
     {% endunless %}
 
     {% continue %}

--- a/_layouts/collections/item.liquid
+++ b/_layouts/collections/item.liquid
@@ -64,8 +64,8 @@ layout: default
     {% assign headline = page_section.first[ 1 ] %}
 
     {% unless headlines == 1 %}
-      <h2 id="{{ headline | slugify }}">{{ headline }}
-        <a href="{{ page.url }}/#{{ headline | slugify }}" class="headline-slug-link"></a>
+      <h2 id="{{ headline | slugify }}">
+        <a href="{{ page.url }}/#{{ headline | slugify }}" class="headline-slug-link">{{ headline }}</a>
       </h2>
     {% endunless %}
 

--- a/_layouts/collections/item.liquid
+++ b/_layouts/collections/item.liquid
@@ -65,7 +65,7 @@ layout: default
 
     {% unless headlines == 1 %}
       <h2 id="{{ headline | slugify }}">
-        <a href="{{ page.url }}/#{{ headline | slugify }}" class="headline-slug-link">{{ headline }}</a>
+        <a href="{{ page.url }}#{{ headline | slugify }}" class="headline-slug-link">{{ headline }}</a>
       </h2>
     {% endunless %}
 


### PR DESCRIPTION
This adds a pilcrow (*¶*) character on hover to the left-hand margin, left of a page’s `h2` if it has an ID, and also adds an anchor linking to that ID.

The idea here is that a user can hover over a page’s `h2`s, and be given an anchor that links to the ID for that heading.

Test site: http://dg-h2-hover-anchor-test.apps.staging.digital.gov.au/foundations/typography/index.html#quotations