### PR TITLE
Bugfix/section heading guide title responsive sizing

### DIFF
--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -57,9 +57,17 @@ main {
     h1 {
       .guide-title {
         display: block;
-        font-size: 0.425em; // 17px.
+        font-size: rem(15);
         font-weight: normal;
         color: $grey;
+
+        @include media($tablet) {
+          font-size: rem(16);
+        }
+
+        @include media($desktop) {
+          font-size: rem(17);
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes the reduced sizing of the ‘*DTA Design Guide*’ text in each section’s `h1`, specifically at smaller breakpoints.