### PR TITLE
Aligns the logo in the header

### DIFF
--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -28,9 +28,64 @@ table {
 // https://github.com/AusDTO/gov-au-ui-kit/blob/master/assets/sass/components/_page-header.scss#L288
 
 header[role='banner'] {
+  .page-header__logo {
+    padding-top: 0;
+    height: 6em;
+
+    @include media($tablet) {
+      height: 8em;
+    }
+
+    .logo {
+      display: inline-block;
+      position: relative;
+      border-bottom: none;
+
+      &:hover,
+      &:focus {
+        background-color: transparent;
+      }
+
+      svg {
+        position: absolute;
+        top: 0;
+        width: rem(48);
+        height: auto;
+
+        @include media($tablet) {
+          width: rem(64);
+        }
+      }
+
+      span {
+        display: inline-block;
+        margin-top: rem(50);
+        margin-left: rem(60);
+        border-bottom: 1px solid $light-aqua;
+
+        @include media($tablet) {
+          margin-top: rem(50);
+          margin-left: rem(80);
+        }
+
+        &:hover,
+        &:focus {
+          background-color: $light-aqua;
+          color: $link-colour;
+        }
+      }
+    }
+  }
+
   .badge--default {
+    display: inline-block;
     margin-left: 0.5em;
     vertical-align: super;
+
+    // I feel a bit dirty too, but hey -- this lets the badge wrap nicely.
+    @include media(min-width 300px max-width 410px) {
+      margin: $small-spacing 0 0 rem(60);
+    }
   }
 
   .breadcrumbs {

--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -31,9 +31,11 @@ header[role='banner'] {
   .page-header__logo {
     padding-top: 0;
     height: 6em;
+    margin-bottom: ($base-spacing * 1.8);
 
     @include media($tablet) {
       height: 8em;
+      margin-bottom: 0;
     }
 
     .logo {

--- a/_includes/header.liquid
+++ b/_includes/header.liquid
@@ -10,7 +10,7 @@
             <use xlink:href="/assets/spritesheet.svg#dg_logo"/>
           </svg>
 
-          {{ site.title }}
+          <span>{{ site.title }}</span>
         </a>
 
         <span class="badge--default">Draft</span>


### PR DESCRIPTION
Sizing:

- 48x for mobile
- 64x for tablet+
- caters for the badge to wrap at 410px (it starts to wrap at around 407px)

See it/test it: http://dg-header-logo-alignment.apps.staging.digital.gov.au/