### PR TITLE
Removes anchors for the final breadcrumb item.

### DIFF
--- a/_includes/header.liquid
+++ b/_includes/header.liquid
@@ -60,13 +60,9 @@
         <li><a href="/{{ page.parent }}">{{ page.parent | capitalize }}</a></li>
         <li>
           {% if page_title_slugified == page.parent %}
-            <a href="/{{ page.parent }}/">
-              Overview
-            </a>
+            Overview
           {% else %}
-            <a href="/{{ page.parent }}/{{ page_title_slugified }}">
-              {{ page.title }}
-            </a>
+            {{ page.title }}
           {% endif %}
         </li>
       </ul>


### PR DESCRIPTION
Removes the anchor link for the third (last) breadcrumb item, since the user would be on that page.