### PR TITLE
Bugfix/header top padding fix

### DIFF
--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -34,7 +34,7 @@ header[role='banner'] {
 
   .page-header__logo {
     padding-top: 0;
-    margin-bottom: ($base-spacing * 1.8);
+    margin-bottom: $tiny-spacing;
 
     @include media($tablet) {
       height: rem(132);

--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -28,13 +28,16 @@ table {
 // https://github.com/AusDTO/gov-au-ui-kit/blob/master/assets/sass/components/_page-header.scss#L288
 
 header[role='banner'] {
+  .page-header {
+    padding-top: 0;
+  }
+
   .page-header__logo {
     padding-top: 0;
-    height: 6em;
     margin-bottom: ($base-spacing * 1.8);
 
     @include media($tablet) {
-      height: 8em;
+      height: rem(132);
       margin-bottom: 0;
     }
 


### PR DESCRIPTION
Minor quick header fix for the site-nav’s logo (white)spacing-ing.

Before/afters—

***

**Before**
![screen shot 2016-12-02 at 4 07 26 pm](https://cloud.githubusercontent.com/assets/52766/20823601/d9bc0cd6-b8a9-11e6-8854-18d6cae1584a.png)

**After**
![screen shot 2016-12-02 at 4 07 00 pm](https://cloud.githubusercontent.com/assets/52766/20823605/e425d97c-b8a9-11e6-814e-c57adc371952.png)

***

**Before**
![screen shot 2016-12-02 at 4 08 13 pm](https://cloud.githubusercontent.com/assets/52766/20823622/f7e152ca-b8a9-11e6-8d19-56701f50f0e1.png)

**After**
![screen shot 2016-12-02 at 4 09 17 pm](https://cloud.githubusercontent.com/assets/52766/20823642/19c2d9d6-b8aa-11e6-84ea-82b7a8abc429.png)