### PR TITLE
Bugfix/section contents index link edits

### DIFF
--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -202,7 +202,6 @@ main {
 .guide-example {
   border: solid $guide-eg-border-width $lighter-grey;
   border-radius: $base-border-radius;
-  margin: $base-spacing 0;
   padding-top: 0;
 
   .guide-example--heading {

--- a/_layouts/collections/item.liquid
+++ b/_layouts/collections/item.liquid
@@ -65,7 +65,7 @@ layout: default
 
     {% if headlines > 1 %}
       {% unless forloop.first %}
-        <span class="back-to-index-link"><a href="#index-links">Back to section index &uarr;</a></span>
+        <span class="back-to-index-link"><a href="#index-links">Back to contents &uarr;</a></span>
       {% endunless %}
       <h2 id="{{ headline | slugify }}">
         <a href="{{ page.url }}#{{ headline | slugify }}" class="headline-slug-link">{{ headline }}</a>


### PR DESCRIPTION
Fixes a margin issue (for when back to top contents links sit after guidance accordions, or just code blocks).

Also edits the link text in line with what Jools was after as per: https://github.com/AusDTO/dto-design-guide/pull/55#issuecomment-265042120