### PR TITLE
Adds a PR template -- copied from the UI-Kit's repo. -- fixes #23

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Use the title line as the title of your pull request, then delete these comment 
 
 ## Description
 
-Include a high-level description for what the pull request fixes and links to Github issues it would resolve.
+Include a high-level description for what the pull request fixes and links to GitHub issues it resolves.
 
 ## Additional information
 
@@ -19,7 +19,7 @@ Include a high-level description for what the pull request fixes and links to Gi
 
 ## Definition of Done
 
-- [ ] Content/documentation reviewed by Julian or someone in the Content Team
+- [ ] Content/documentation reviewed by Jools or someone in the #content-design team
 - [ ] UX reviewed by Gary or someone the Design team
 - [ ] Code reviewed by one of the core developers
 - [ ] Acceptance Testing

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,14 +8,18 @@ Use the title line as the title of your pull request, then delete these comment 
 
 ## Description
 
+<!--
 Include a high-level description for what the pull request fixes and links to GitHub issues it resolves.
+-->
 
 ## Additional information
 
+<!--
 * Relevant research and support documents
 * Screen shot images
 * Notes
 * etc.
+-->
 
 ## Definition of Done
 
@@ -23,9 +27,6 @@ Include a high-level description for what the pull request fixes and links to Gi
 - [ ] UX reviewed by Gary or someone the Design team
 - [ ] Code reviewed by one of the core developers
 - [ ] Acceptance Testing
-  - [ ] [Cross-browser tested against standard browser matrix](https://docs.google.com/spreadsheets/d/1B8pGWSiFbWhurnDISvD2MKnI0IF_T8tU2sl1naZCw1E/edit#gid=1030964576)
-  - [ ] Tested on multiple devices (TBD)
   - [ ] HTML5 validation (CircleCI)
   - [ ] Accessibility testing & WCAG2 compliance
 - [ ] Stakeholder/PO review
-- [ ] CHANGELOG updated

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--
+
+# Title Line Template: [Brief statement describing what this pull request fixes.]
+
+Use the title line as the title of your pull request, then delete these comment lines.
+
+-->
+
+## Description
+
+Include a high-level description for what the pull request fixes and links to Github issues it would resolve.
+
+## Additional information
+
+* Relevant research and support documents
+* Screen shot images
+* Notes
+* etc.
+
+## Definition of Done
+
+- [ ] Content/documentation reviewed by Julian or someone in the Content Team
+- [ ] UX reviewed by Gary or someone the Design team
+- [ ] Code reviewed by one of the core developers
+- [ ] Acceptance Testing
+  - [ ] [Cross-browser tested against standard browser matrix](https://docs.google.com/spreadsheets/d/1B8pGWSiFbWhurnDISvD2MKnI0IF_T8tU2sl1naZCw1E/edit#gid=1030964576)
+  - [ ] Tested on multiple devices (TBD)
+  - [ ] HTML5 validation (CircleCI)
+  - [ ] Accessibility testing & WCAG2 compliance
+- [ ] Stakeholder/PO review
+- [ ] CHANGELOG updated


### PR DESCRIPTION
Adds a PR template.

In particular @AusDTO/guides please take a look at the DoD checklist, which we will likely want to modify further for the needs of the DG, as distinct from the uikit.

This, alongside #64 should account for #23.