### PR TITLE
Adds correct syntax highlighting lang, fixed #57

### DIFF
--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -196,8 +196,27 @@ main {
   }
 }
 
-// Custom styling for the rendered example and code blocks.
+// Styling for code blocks outside of the rendered + HTML code examples.
+.highlight {
+  pre {
+    overflow: auto;
+    white-space: pre;
 
+    code {
+      font-size: rem(14);
+    }
+
+    .language-shell {
+      display: block;
+      margin-bottom: $base-spacing;
+      font-size: rem(15);
+    }
+  }
+}
+
+
+// Custom styling for the rendered example and code blocks.
+//
 // Extract the repeating bits plz
 .guide-example {
   border: solid $guide-eg-border-width $lighter-grey;
@@ -225,7 +244,7 @@ main {
     padding: 0 ($medium-spacing + $small-spacing);
   }
 
-  figure {
+  .highlight {
     border-top-left-radius: $base-border-radius;
     border-top-right-radius: $base-border-radius;
 
@@ -236,9 +255,6 @@ main {
       padding-top: $medium-spacing;
       padding-left: ($medium-spacing + $small-spacing);
       padding-right: $small-spacing;
-      font-size: rem(16);
-      overflow: auto;
-      white-space: pre;
     }
   }
 

--- a/_getting-started/developers/accessibility.md
+++ b/_getting-started/developers/accessibility.md
@@ -2,9 +2,9 @@ UI&#8209;Kit aims to be WCAG2 AA compliant, and AAA where possible.
 
 Run accessibility tests:
 
-```
+{% highlight shell %}
 npm test
-```
+{% endhighlight %}
 
 Check you meet [Pa11y's requirements for automated accessibility testing](https://github.com/pa11y/pa11y#requirements).
 

--- a/_getting-started/developers/build.md
+++ b/_getting-started/developers/build.md
@@ -5,9 +5,9 @@
 
 Install dependencies:
 
-```
+{% highlight shell %}
 npm install
-```
+{% endhighlight %}
 
 We use Bourbon 4.2.7. We include its `.scss` files directly rather than calling it via its node (or gem) package.
 
@@ -16,21 +16,23 @@ Bourbon and Neat are in `/assets/sass/vendor`.
 ### Using npm
 
 Run a build:
-```
+
+{% highlight shell %}
 npm run-script build
-```
+{% endhighlight %}
 
 Run a build with livereloading:
-```
+
+{% highlight shell %}
 npm start
-```
+{% endhighlight %}
 
 ### Key libraries
 
-- gulp ^3.9.1
-- gulp-sass ^2.3.1
-- kss ^3.0.0-beta.14
-- sass-lint ^1.7.0
+- gulp `^3.9.1`
+- gulp-sass `^2.3.1`
+- kss `^3.0.0-beta.14`
+- sass-lint `^1.7.0`
 
 ^ = compatible with version (see <a href="https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004" rel="external">semver</a>)
 

--- a/_getting-started/developers/install.md
+++ b/_getting-started/developers/install.md
@@ -1,8 +1,8 @@
 Link to UI&#8209;Kit in the `<head>`:
 
-```
+{% highlight html %}
 <link rel="stylesheet" type="text/css" href="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.css"/>
 <script type="text/javascript" src="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.js"></script>
-```
+{% endhighlight %}
 
 The UI&#8209;Kit CSS is at `./build/latest/ui-kit.css`


### PR DESCRIPTION
Hey @joolswood,

I’ve added the correct highlighting syntax to achieve syntax highlighting as desired — we want to basically specify the language.

I’ve also tweaked the SASS a tiny bit to ensure our shell command code styling is a bit larger to read. I think these would look a bit better if we returned to the dark/inverted code highlighting style, but I didn’t see an easy way to use the dark/inverted styling for *just* the shell command code blocks…

…maybe we can approach Gaz next week and see what he thinks re. going back to the dark styling altogether, since we want to hide our HTML code blocks by default? :) 

@dominikwilkowski could you take a quick squiz over the SASS edits — nothin’ major.