### PR TITLE
Re-adds the SCSS from the KSS partial that fixes overflowing rendered bugs, fixed #40

### DIFF
--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -223,6 +223,13 @@ main {
   .guide-example--rendered {
     margin: ($base-spacing * 1.5) 0;
     padding: 0 ($medium-spacing + $small-spacing);
+
+    // This ensures that we don’t allow rendered examples to overflow their
+    // containing boxes.
+    .wrapper {
+      box-sizing: border-box;
+      min-width: 0;
+    }
   }
 
   figure {


### PR DESCRIPTION
This is a fix for #40.

The two instances where this bug occurs:

- Patterns > Link styles > Special link blocks
- Components > Navigation > Footer navigation