### PR TITLE
Getting started > For developers content update

### DIFF
--- a/_getting-started/design-principles/index.md
+++ b/_getting-started/design-principles/index.md
@@ -3,7 +3,8 @@ layout: collections/item
 title: Design principles
 ---
 
-<p class="abstract">Use UI&#8209;Kit to build consistent and responsive services that meet the user's needs.</p>
+Use UI-Kit to build consistent and responsive services that meet the user's needs.
+{: .abstract }
 
 These principles build on the <a href="https://www.dta.gov.au/standard/" rel="external">Digital Service Standard</a> and the <a href="https://www.dta.gov.au/standard/design-principles/" rel="external">DTA design principles</a>.
 

--- a/_getting-started/developers/accessibility.md
+++ b/_getting-started/developers/accessibility.md
@@ -8,10 +8,10 @@ npm test
 
 These tests are part of our build process.
 
-We use <a href="https://github.com/pa11y/pa11y" rel="external">Pa11y</a> for the automated testing. Pa11y in turn uses <a href="http://squizlabs.github.io/HTML_CodeSniffer/" rel="external">HTML_CodeSniffer</a>, which we also use for manual testing.
+We use <a href="https://github.com/pa11y/pa11y" rel="external">Pa11y</a> for the automated testing. Pa11y uses <a href="http://squizlabs.github.io/HTML_CodeSniffer/" rel="external">HTML_CodeSniffer</a>. We also use HTML_CodeSniffer for manual testing.
 
-Use an automated accessibility testing to catch common mistakes. Automated testing is not a substitution for testing with users.
+We use an automated accessibility testing to catch common mistakes. Automated testing is not a substitution for testing with users.
 
-Where possible we also test with users. These sessions commonly test products that use the UI-Kit, because it is difficult for us to test our components and patterns in isolation.
+Where possible we test with users. These tests are usually on products that use the UI-Kit, because it is difficult to test components and patterns in isolation.
 
-In the future we intend to also be audited.
+We plan to audit UI-Kit.

--- a/_getting-started/developers/accessibility.md
+++ b/_getting-started/developers/accessibility.md
@@ -1,4 +1,4 @@
-UI&#8209;Kit aims to be WCAG2 AA compliant, and AAA where possible.
+UI-Kit aims to be WCAG2 AA compliant, and AAA where possible and appropriate.
 
 Run accessibility tests:
 
@@ -6,14 +6,8 @@ Run accessibility tests:
 npm test
 {% endhighlight %}
 
-Check you meet [Pa11y's requirements for automated accessibility testing](https://github.com/pa11y/pa11y#requirements).
+These tests are part of our build process, and are intended to catch common mistakes. Pa11y uses the <a href="http://squizlabs.github.io/HTML_CodeSniffer/" rel="external">HTML_CodeSniffer</a>, which we also use for manual testing.
 
-We use automated testing:
-- WCAG 2.0 criteria using <a href="http://squizlabs.github.io/HTML_CodeSniffer/" rel="external">HTML_CodeSniffer</a>
-- HTML validation using <a href="http://validator.github.io/validator/" rel="external">Nu HTML Checker</a>.
+Where possible we also test with users. These sessions commonly test products that use the UI-Kit, because it is difficult for us to test our components and patterns in isolation.
 
-We are working on:
-- manual evaluation using <a href="http://wave.webaim.org/" rel="external">Wave by WebAIM</a>
-- manual checking of page structure, content and keyboard navigation
-- testing with users and assistive technologies
-- an audit.
+In the future we intend to also be audited.

--- a/_getting-started/developers/accessibility.md
+++ b/_getting-started/developers/accessibility.md
@@ -6,7 +6,11 @@ Run accessibility tests:
 npm test
 {% endhighlight %}
 
-These tests are part of our build process, and are intended to catch common mistakes. Pa11y uses the <a href="http://squizlabs.github.io/HTML_CodeSniffer/" rel="external">HTML_CodeSniffer</a>, which we also use for manual testing.
+These tests are part of our build process.
+
+We use <a href="https://github.com/pa11y/pa11y" rel="external">Pa11y</a> for the automated testing. Pa11y in turn uses <a href="http://squizlabs.github.io/HTML_CodeSniffer/" rel="external">HTML_CodeSniffer</a>, which we also use for manual testing.
+
+Use an automated accessibility testing to catch common mistakes. Automated testing is not a substitution for testing with users.
 
 Where possible we also test with users. These sessions commonly test products that use the UI-Kit, because it is difficult for us to test our components and patterns in isolation.
 

--- a/_getting-started/developers/browser.md
+++ b/_getting-started/developers/browser.md
@@ -1,11 +1,9 @@
-The UI-Kit team needs to support all of our users, regardless of their device, web browser or other user agent.
+UI-Kit needs to support all of our users, regardless of their device, web browser or other user agent.
 
 Equal access to information about laws and government programs is a legal requirement under the <a href="https://www.legislation.gov.au/Latest/C2016C00763" rel="external">Disability Discrimination Act (1992)</a>.
 
-We don’t list unsupported devices and browsers.
+<a href="https://github.com/AusDTO/gov-au-ui-kit/blob/develop/BROWSER-SUPPORT.md" rel="external">Read the browser support document</a>.
 
-We are aiming for a solid HTML mobile-first foundation that provides functional support for the browsers and devices of all of our users.
+We don’t list unsupported devices and browsers. We are aiming for a solid HTML mobile-first foundation that provides functional support for the browsers and devices of all of our users.
 
-<a href="https://github.com/AusDTO/gov-au-ui-kit/blob/develop/BROWSER-SUPPORT.md" rel="external">Read the browser support document for more detailed information</a>.
-
-We have written <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/develop/assets/sass/utils/_mixins.scss#L2" rel="external">a small SASS mixin for conditional handling of Internet Explorer specific overrides</a>. Use this when extending the UI-Kit.
+We have written <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/develop/assets/sass/utils/_mixins.scss#L2" rel="external">a SASS mixin for conditional handling of Internet Explorer specific overrides</a>. Use this when extending the UI-Kit.

--- a/_getting-started/developers/browser.md
+++ b/_getting-started/developers/browser.md
@@ -1,9 +1,11 @@
-<a href="https://gov-au-ui-kit.apps.staging.digital.gov.au/BROWSER-SUPPORT.md" rel="external">Read the cross browser and device support table</a>.
+The UI-Kit team needs to support all of our users, regardless of their device, web browser or other user agent.
 
-The kit uses a <a href="https://github.com/AusDTO/gov-au-ui-kit/tree/master/assets/sass" rel="external">conditional styling mixin for specific versions of IE</a>. Use this when extending the kit.
+Equal access to information about laws and government programs is a legal requirement under the <a href="https://www.legislation.gov.au/Latest/C2016C00763" rel="external">Disability Discrimination Act (1992)</a>.
 
-We are working on:
+We don’t list unsupported devices and browsers.
 
-- automated browser testing as part of our build process
-- manual testing of all CSS, JS and markup
-- documenting browser support for each component.
+We are aiming for a solid HTML mobile-first foundation that provides functional support for the browsers and devices of all of our users.
+
+<a href="https://github.com/AusDTO/gov-au-ui-kit/blob/develop/BROWSER-SUPPORT.md" rel="external">Read the browser support document for more detailed information</a>.
+
+We have written <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/develop/assets/sass/utils/_mixins.scss#L2" rel="external">a small SASS mixin for conditional handling of Internet Explorer specific overrides</a>. Use this when extending the UI-Kit.

--- a/_getting-started/developers/build.md
+++ b/_getting-started/developers/build.md
@@ -21,7 +21,7 @@ Run a build:
 npm run-script build
 {% endhighlight %}
 
-Run a build with livereloading:
+Run a build with live reloading:
 
 {% highlight shell %}
 npm start
@@ -29,12 +29,10 @@ npm start
 
 ### Key libraries
 
-- gulp `^3.9.1`
-- gulp-sass `^2.3.1`
-- kss `^3.0.0-beta.14`
-- sass-lint `^1.7.0`
-
-^ = compatible with version (see <a href="https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004" rel="external">semver</a>)
+- `gulp ^3.9.1`
+- `gulp-sass ^2.3.1`
+- `kss ^3.0.0-beta.14`
+- `sass-lint ^1.7.0`
 
 The build also uses:
 - `sass-lint` for linting
@@ -42,4 +40,4 @@ The build also uses:
 - `autoprefixer` for adding CSS vendor prefixes
 - `AusDTO/gulp-html` for HTML validation.
 
-The CI build is available as a shell script at `bin/cibuild.sh`.
+The CI (continuous integration) script is available as a shell script at `bin/cibuild.sh`.

--- a/_getting-started/developers/index.md
+++ b/_getting-started/developers/index.md
@@ -21,4 +21,4 @@ sections:
 
 <p class="abstract">UI-Kit is a CSS and JS framework using <a href="http://bourbon.io/" rel="external">Bourbon</a> and <a href="http://neat.bourbon.io/" rel="external">Neat</a>.</p>
 
-<a href="https://github.com/AusDTO/gov-au-ui-kit/blob/develop/RELEASING.md" rel="external">Fork UI-Kit on GitHub</a>.
+<a href="https://github.com/AusDTO/gov-au-ui-kit/" rel="external">View UI-Kit on GitHub</a>.

--- a/_getting-started/developers/install.md
+++ b/_getting-started/developers/install.md
@@ -1,8 +1,5 @@
-Link to UI&#8209;Kit in the `<head>`:
+Download the UI-Kit precompiled files:
 
-{% highlight html %}
-<link rel="stylesheet" type="text/css" href="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.css"/>
-<script type="text/javascript" src="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.js"></script>
-{% endhighlight %}
-
-The UI&#8209;Kit CSS is at `./build/latest/ui-kit.css`
+- [CSS, minified](https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.css)
+- [JavaScript, minified](https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.js)
+- [Image assets, zipped](https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/images.zip)


### PR DESCRIPTION
This is a PR for #58.

Primarily it:

- changes the direct HTML of example `<link>`s that linked to our staging minified files and instead links to them asking the user to download them
- overhauled/updated the a11y and browser support sections
- fixes the correct link and link text to the UI-Kit repo
- removes unnecessary semver info & expands on an abbreviation

Please review for both accuracy, and please consider word-smithing as needed/appropriate :)