### PR TITLE
Bugfix: missing baseurl content links + back-to-contents skiplink margins

### DIFF
--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -318,11 +318,18 @@ main {
     }
   }
 
+  .guide-example + .back-to-index-link {
+    margin-top: rem(82);
+  }
+
+  p + .back-to-index-link {
+    margin-top: rem(64);
+  }
+
   .back-to-index-link {
     display: block;
     font-size: $small-font-size;
     float: right;
-    margin-top: rem(82);
   }
 
   // Custom styling for sidebar

--- a/_components/accordions/index.md
+++ b/_components/accordions/index.md
@@ -23,4 +23,5 @@ sections:
   - md: Building top
 ---
 
-<p class="abstract">Accordions help users to see only the content they need.<p>
+Accordions help users to see only the content they need.
+{: .abstract }

--- a/_components/accordions/usability-guidance.md
+++ b/_components/accordions/usability-guidance.md
@@ -1,3 +1,3 @@
 We will provide an **expand/collapse all** feature. You must use this if there are multiple accordion elements on a page.
 
-Use [definition or description lists](/foundations/typography/index.html#lists) for glossaries instead of accordions.
+Use [definition or description lists]({{ site.baseurl }}/foundations/typography/index.html#lists) for glossaries instead of accordions.

--- a/_getting-started/index.md
+++ b/_getting-started/index.md
@@ -21,5 +21,5 @@ The DTA Design Guide documents the design system the Digital Transformation Agen
 ## Get help
 
 - [Email the Guides team](mailto:guides@digital.gov.au).
-- Log an issue in the <a href="https://github.com/AusDTO/gov-au-ui-kit/issues" rel="external">UI&#8209;Kit GitHub issue register</a>.
-- If you work in a Digital Transformation Agency team join the <a href="https://ausdto.slack.com/messages/guides-uikit/" rel="external">Slack channel #guides&#8209;uikit</a>.
+- Log an issue in the <a href="https://github.com/AusDTO/gov-au-ui-kit/issues" rel="external">UI-Kit GitHub issue register</a>.
+- If you work in a Digital Transformation Agency team join the <a href="https://ausdto.slack.com/messages/guides-uikit/" rel="external">Slack channel #guides-uikit</a>.

--- a/_getting-started/index.md
+++ b/_getting-started/index.md
@@ -7,15 +7,15 @@ layout: collections/overview
 
 The DTA Design Guide documents the design system the Digital Transformation Agency is building with the <a href="https://github.com/AusDTO/gov-au-ui-kit" rel="external">UI-Kit CSS and JS framework</a>.
 
-- [Foundations](/foundations/) describes how to use the core modules all services need: typography, layout and colours.
-- [Components](/components/) documents how to use the UI-Kit building blocks. For example, [forms & buttons](/components/forms-buttons/).
-- [Patterns](/patterns/) shows how to combine the building block components to meet user needs. For example, [navigation](/patterns/navigation/).
+- [Foundations]({{ site.baseurl }}/foundations/) describes how to use the core modules all services need: typography, layout and colours.
+- [Components]({{ site.baseurl }}/components/) documents how to use the UI-Kit building blocks. For example, [forms & buttons]({{ site.baseurl }}/components/forms-buttons/).
+- [Patterns]({{ site.baseurl }}/patterns/) shows how to combine the building block components to meet user needs. For example, [navigation]({{ site.baseurl }}/patterns/navigation/).
 - Templates will contain examples of common service pages with multiple patterns. For example 'Contact us' and media releases.
 
 ## Use UI-Kit
 
-- [Design principles for using UI&#8209;Kit](/getting-started/design-principles/).
-- [Develop with UI-Kit](/getting-started/developers/).
+- [Design principles for using UI&#8209;Kit]({{ site.baseurl }}/getting-started/design-principles/).
+- [Develop with UI-Kit]({{ site.baseurl }}/getting-started/developers/).
 - Use the DTA Design Guide with the <a href="http://content-style-guide.apps.staging.digital.gov.au/" rel="external">DTA Content Style Guide for writing</a>.
 
 ## Get help

--- a/_patterns/navigation/building-top.md
+++ b/_patterns/navigation/building-top.md
@@ -3,4 +3,4 @@
 - Use the given state classes to show which page the user is on.
 - Use short navigation links. They don't have to be the full page title.
 - Test with users to ensure the navigation hierarchy is not too long or too deep.
-- Use the [correct colour contrast](/foundations/colours/index.html#text-accessibility) for breadcrumbs and inline links.
+- Use the [correct colour contrast]({{ site.baseurl }}/foundations/colours/index.html#text-accessibility) for breadcrumbs and inline links.


### PR DESCRIPTION
## Description

Applies `{{ site.baseurl }}` to internal links, and adds a quickfix for the margin-top of the back-to-contents links within each section.

## Definition of Done

- [ ] Content/documentation reviewed by Jools or someone in the #content-design team
- [ ] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [ ] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance
- [x] Stakeholder/PO review
