### PR TITLE
Bugfixes: further site.baseurl fixes + contents skip link whitespace

### DIFF
--- a/_assets/scss/design-guide.scss
+++ b/_assets/scss/design-guide.scss
@@ -60,7 +60,6 @@ table {
     background-repeat: no-repeat;
     background-position: calc(100% - 50%) calc(100% - 60%);
     background-size: 70%;
-    //background-position: calc(100% - 15%) calc(100% - 25%);
 
     @include media($tablet) {
       background-position: bottom 10% left 8%;
@@ -318,11 +317,18 @@ main {
     }
   }
 
-  .guide-example + .back-to-index-link {
+  // These provide adequate margins for the back to contents links.
+  //
+  // It would be nice to improve the templates for these to have the whitespace
+  // for each of the sections handled in a more consistent manner, eg.
+  // http://alistapart.com/article/axiomatic-css-and-lobotomized-owls
+  .guide-example + .back-to-index-link,
+  details + .back-to-index-link {
     margin-top: rem(82);
   }
 
-  p + .back-to-index-link {
+  p + .back-to-index-link,
+  ul + .back-to-index-link {
     margin-top: rem(64);
   }
 

--- a/_foundations/layout/responsive-breakpoints-guidance.md
+++ b/_foundations/layout/responsive-breakpoints-guidance.md
@@ -1,17 +1,18 @@
-<details open data-label="responsive-breakpoints-guidance-accordion" aria-expanded="false">
-  <summary>Guidance <span class="visuallyhidden">for responsive breakpoints</span></summary>
-  <div class="accordion-panel">
+{% assign ID = "responsive-breakpoints" %}
 
-    <h4>Customising elements</h4>
-    <p>If you give an element a modified grid setting consider the implications for all breakpoints. The Digital Service Standard recommends you <a href="https://www.dto.gov.au/standard/6-consistent-and-responsive/" rel="external">build using mobile first design principles</a>.</p>
-    <p>Please also consider the <a href="/foundations/typography/index.html#typeface">font size</a> at different breakpoints.</p>
-    <pre>
-    <code>
-    $mobile: new-breakpoint(min-width 420px 8);
-    $tablet: new-breakpoint(min-width 768px 12);
-    $desktop: new-breakpoint(min-width $max-width 16);</code>
-    </pre>
+{% capture content %}
+#### Customising elements
 
+If you give an element a modified grid setting consider the implications for all breakpoints. The Digital Service Standard recommends you <a href="https://www.dto.gov.au/standard/6-consistent-and-responsive/" rel="external">build using mobile first design principles</a>.
 
-  </div>
-</details>
+Please also consider the [font size]({{ site.baseurl }}/foundations/typography/index.html#typeface) at different breakpoints.
+
+{% highlight scss %}
+$mobile: new-breakpoint(min-width 420px 8);
+$tablet: new-breakpoint(min-width 768px 12);
+$desktop: new-breakpoint(min-width $max-width 16);
+{% endhighlight %}
+
+{% endcapture %}
+
+{% include guidance.liquid  content = content  ID = ID %}

--- a/_foundations/layout/sidebar-guidance.md
+++ b/_foundations/layout/sidebar-guidance.md
@@ -7,10 +7,10 @@ To move the sidebar to the left use the class `.sidebar-has-controls` on the par
 {% highlight html %}
 <main class="sidebar-has-controls">
   <aside class="sidebar">
-    &hellip;
+    ...
   </aside>
   <article role="main" id="content" class="content-main">
-    &hellip;
+    ...
   </article>
 </main>
 {% endhighlight %}

--- a/_foundations/typography/links-guidance.md
+++ b/_foundations/typography/links-guidance.md
@@ -4,8 +4,8 @@
 - Link to only what the user needs. Too many links can make content hard to read.
 - Use keywords that the user will understand and describe the destination.
 - Aim to add links in paragraphs, rather than lists at the end.
-- Use 'see more' links at the end of <a href="/components/list-styles/index.html">list styles</a> to take the user to a index page of all items.
-- Use placeholder styling (greyed out links) to show actions that a user can't currently take. Explain why the action isn't available and when it will be. Placeholder styling only works in <code>&lt;span&gt;</code> tags, not <code>&lt;a&gt;</code>.
+- Use 'see more' links at the end of [list styles]({{ site.baseurl }}/components/list-styles/) to take the user to a index page of all items.
+- Use placeholder styling (greyed out links) to show actions that a user can't currently take. Explain why the action isn't available and when it will be. Placeholder styling only works in `<span>` tags, not `<a>`.
 {% endcapture %}
 
 {% include guidance.liquid  content = content  ID = ID %}

--- a/_foundations/typography/typeface-guidance.md
+++ b/_foundations/typography/typeface-guidance.md
@@ -6,7 +6,7 @@
 - Refer to the `$base-sans-serif` variable to access the sans-serif font-stack.
 - Use monospace fonts only for numeric data in tables or for code snippets.
 - Set `line-height` (leading) to at least 1.5 (UI-Kit uses 1.6). Use 'unitless' line-heights. These act as a multiplier of the font-size.
-- UI-Kit applies a maximum width of 38 rem (about 70 characters) to typographic elements in the main content container (`h1`–`h5`, `p`, `li` and `dl`). This gives a <a href="https://www.smashingmagazine.com/2014/09/balancing-line-length-font-size-responsive-web-design/#line-length-measure-and-readin" rel="external">readable line length</a>.
+- UI-Kit applies a maximum width of 38 rem (about 70 characters) to typographic elements in the main content container (`h1`–`h5`, `p`, `li` and `dl`). This gives a <a href="https://www.smashingmagazine.com/2014/09/balancing-line-length-font-size-responsive-web-design/#line-length-measure-and-reading" rel="external">readable line length</a>.
 - Don’t apply a `font-size` to a container element (for example, a `footer`); apply them to the content elements directly.
 {% endcapture %}
 

--- a/_includes/head.liquid
+++ b/_includes/head.liquid
@@ -3,13 +3,13 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link rel="apple-touch-icon" sizes="180x180" href="/design-guide/apple-touch-icon.png">
-  <link rel="icon" type="image/png" href="/design-guide/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="/design-guide/favicon-16x16.png" sizes="16x16">
-  <link rel="manifest" href="/design-guide/manifest.json">
-  <link rel="mask-icon" href="/design-guide/safari-pinned-tab.svg" color="#00a1bb">
-  <link rel="shortcut icon" href="/design-guide/favicon.ico">
-  <meta name="msapplication-config" content="/design-guide/browserconfig.xml">
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}/apple-touch-icon.png">
+  <link rel="icon" type="image/png" href="{{ site.baseurl }}/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="{{ site.baseurl }}/favicon-16x16.png" sizes="16x16">
+  <link rel="manifest" href="{{ site.baseurl }}/manifest.json">
+  <link rel="mask-icon" href="{{ site.baseurl }}/safari-pinned-tab.svg" color="#00a1bb">
+  <link rel="shortcut icon" href="{{ site.baseurl }}/favicon.ico">
+  <meta name="msapplication-config" content="{{ site.baseurl }}/browserconfig.xml">
   <meta name="theme-color" content="#ffffff">
 
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}{% unless page.url == '/' %} - DTA Design Guide{% endunless %}</title>

--- a/_layouts/collections/item.liquid
+++ b/_layouts/collections/item.liquid
@@ -68,7 +68,7 @@ layout: section
     {% endunless %}
 
     <h2 id="{{ headline | slugify }}">
-      <a href="{{ page.url }}#{{ headline | slugify }}" class="headline-slug-link">{{ headline }}</a>
+      <a href="{{ site.baseurl }}/{{ page.collection }}/{{ page.section | slugify }}/index.html#{{ headline | slugify }}" class="headline-slug-link">{{ headline }}</a>
     </h2>
 
     {% continue %}

--- a/browserconfig.xml
+++ b/browserconfig.xml
@@ -2,7 +2,7 @@
 <browserconfig>
   <msapplication>
     <tile>
-      <square150x150logo src="/design-guide/mstile-150x150.png"/>
+      <square150x150logo src="{{ site.baseurl }}/mstile-150x150.png"/>
       <TileColor>#00a1bb</TileColor>
     </tile>
   </msapplication>


### PR DESCRIPTION
## Description

PR holds a range of bugfixes that probably could have been done better split up, but hey, here is… fixes:

- a number of content links broken in prod due to missing `site.baseurl`
- missing `site.baseurl` in the head include for the `link rel="icon"`
- attempts a fix for the `browserconfig.xml` icon config (hoping that `{{ site.baseurl }}` is processed here, as it would be in other XML files (eg feed or sitemaps)…
- further SASS patching for the “back to contents” link within each section, depending on what preceded it

## Additional information

Egs of a page where the back to contents skip links were borked:

- http://guides.service.gov.au/design-guide/patterns/navigation/index.html#building-navigation
- http://guides.service.gov.au/design-guide/patterns/navigation/index.html#local-navigation

Also, I noticed that the *Layout* section is missing the *Responsive breakpoint* stuff entirely — the `-top.md` for it is empty, and the guidance was still using the old HTML markup for `<details>` — I checked the IA spreadsheet and it looks like it should be there… maybe an oversight, or something intentionally left out for now by Jools, but defs. something we should check up when he gets back.

## Definition of Done

- [ ] Content/documentation reviewed by Jools or someone in the #content-design team
- [ ] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [ ] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
  - [ ] Accessibility testing & WCAG2 compliance
- [x] Stakeholder/PO review
