### PR TITLE
Feature/callout documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -150,6 +150,8 @@ defaults:
         title: Navigation
       - folder: calendar-table
         title: Calendar table
+      - folder: callouts
+        title: Callouts
 
 - scope: # TEMPLATES CATEGORY
     path: _templates

--- a/_patterns/callouts/callout-guidance.md
+++ b/_patterns/callouts/callout-guidance.md
@@ -1,0 +1,8 @@
+{% assign ID = "callouts" %}
+
+{% capture content %}
+- You can use these classes on paragraphs or a wrapping element, like an `<aside>` or a `<div>`.
+- Use the `.callout--calendar` to highlight an important date, but use the [Calendar table pattern](/patterns/calendar-table) for a table of dates.
+{% endcapture %}
+
+{% include guidance.liquid  content = content  ID = ID %}

--- a/_patterns/callouts/index.md
+++ b/_patterns/callouts/index.md
@@ -1,0 +1,14 @@
+---
+layout: collections/item
+title: Callouts
+section: Callouts
+sections:
+  - headline: Callouts
+  - code:
+    - scss: assets/sass/components/_typogaphy
+    - markup: callouts-examples
+  - md: Callout guidance
+---
+
+Use callouts to notify and alert users of important snippets of information.
+{: .abstract }

--- a/_patterns/index.md
+++ b/_patterns/index.md
@@ -8,5 +8,6 @@ layout: collections/overview
 Guidance on:
 - using site, local and contents navigation
 - tables for showing date information.
+- alerts and callouts
 
 We are working on more patterns.


### PR DESCRIPTION
## Description

Adds basic (missing) documentation for the existing ([and three new](https://github.com/AusDTO/gov-au-ui-kit/pull/452)) callouts under the *Patterns* section.

When merged this should fix for https://github.com/AusDTO/dto-design-guide/issues/119

That issue holds the bulk of the bg info.

Happy to leave this PR open for Jools to work on, or we could merge and ensure Jools sees it when he comes back — undoubtedly there’s content debt here that we will want to fix…

## Additional information

Screenshot:

![screen shot 2017-01-12 at 11 59 48 am](https://cloud.githubusercontent.com/assets/52766/21872858/031dfb72-d8bf-11e6-8d58-d5b856f0676a.png)

## Definition of Done

- [ ] Content/documentation reviewed by Jools or someone in the #content-design team
- [ ] UX reviewed by Gary or someone the Design team
- [ ] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance
- [ ] Stakeholder/PO review
