### PR TITLE
Commonwealth Coat of Arms MIT license exclusion notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,10 @@ for jekyll to reuse. The script also generates the `_data/uikit.json` after it p
 ## Contributing
 
 Open an issue first to discuss potential changes/additions. We encourage you to read our
-[Contributor Code of Conduct](https://github.com/AusDTO/gov-au-ui-kit/blob/master/code_of_conduct.md). By ensuring that all contributors follow this guide we
-can maintain an inclusive and friendly community.
+[Contributor Code of Conduct](https://github.com/AusDTO/gov-au-ui-kit/blob/master/code_of_conduct.md). By ensuring that all contributors follow this guide we can maintain an inclusive and friendly community.
 
 ## Copyright & license
 
-© Copyright Commonwealth of Australia. Licensed under the [MIT license](https://github.com/AusDTO/dto-design-guide/blob/master/LICENSE.md).
+© Copyright Commonwealth of Australia.
+
+With the exception of the Commonwealth Coat of Arms and where otherwise noted, this work is [licensed under the MIT license](https://github.com/AusDTO/dto-design-guide/blob/master/LICENSE.md).

--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -34,10 +34,8 @@
           </a>
         </p>
 
-        <p>
-          &copy; Commonwealth of Australia,
-          <a href="{{ site.github_url }}/blob/master/LICENSE.md" rel="external license">licensed under the MIT License</a>.
-        </p>
+        <p>&copy; Commonwealth of Australia.</p>
+        <p>With the exception of the Commonwealth Coat of Arms and where otherwise noted, this work is <a href="{{ site.github_url }}/blob/master/LICENSE.md" rel="external license">licensed under the MIT License</a>.</p>
 
         <p><a href="#">Back to top &uarr;</a></p>
       </div>

--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -35,7 +35,7 @@
         </p>
 
         <p>&copy; Commonwealth of Australia.</p>
-        <p>With the exception of the Commonwealth Coat of Arms and where otherwise noted, this work is <a href="{{ site.github_url }}/blob/master/LICENSE.md" rel="external license">licensed under the MIT License</a>.</p>
+        <p>With the exception of the <a href="https://www.dpmc.gov.au/government/commonwealth-coat-arms" rel="external">Commonwealth Coat of Arms</a> and where otherwise noted, this work is <a href="{{ site.github_url }}/blob/master/LICENSE.md" rel="external license">licensed under the MIT License</a>.</p>
 
         <p><a href="#">Back to top &uarr;</a></p>
       </div>


### PR DESCRIPTION
## Description

Appends Coat of Arms license exclusion notice to `README.md`, and to the `footer.liquid` include.

Related issues:

- #97 
- #75 

## Additional information

![screen shot 2017-01-12 at 2 47 07 pm](https://cloud.githubusercontent.com/assets/52766/21876446/25dffe72-d8d7-11e6-907c-b98aebe76e94.png)

Also adds a link to the DPMC CoA page: https://www.dpmc.gov.au/government/commonwealth-coat-arms.

## Definition of Done

- [x] Content/documentation reviewed by Jools or someone in the #content-design team
- [ ] UX reviewed by Gary or someone the Design team
- [ ] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance
- [ ] Stakeholder/PO review
