### PR TITLE
Fixes wrong hex colour for lighter-aqua in colour docs.

### DIFF
--- a/_foundations/colours/palette-guidance.md
+++ b/_foundations/colours/palette-guidance.md
@@ -62,7 +62,7 @@
   <div class="guide-colour">
     <div class="swatch bg-lighter-aqua"></div>
     <p class="text"><strong>lighter aqua</strong><br/>
-      <small><code>$lighter-aqua<br/> #5BCBE3</code></small></p>
+      <small><code>$lighter-aqua<br/> #DEF4F9</code></small></p>
   </div>
 
   <div class="guide-colour">


### PR DESCRIPTION
## Description

`$lighter-aqua` had the wrong hex value given in the documentation (colour palette section).

Thanks go to @jane24 for reporting this: https://github.com/AusDTO/gov-au-ui-kit/issues/463

## Additional information

- [ ] Stakeholder/PO review
