### PR TITLE
Bugfix/tables section guidance double up

### DIFF
--- a/_components/badges/badges-top.md
+++ b/_components/badges/badges-top.md
@@ -1,1 +1,0 @@
-<p class="abstract">A badge can appear inline with a text element.</p>

--- a/_components/badges/index.md
+++ b/_components/badges/index.md
@@ -4,10 +4,10 @@ title: Badges
 section: Typography
 sections:
   - headline: Badges
-  - md: Badges top
   - code:
     - scss: assets/sass/components/_typography
     - markup: Badges
 ---
 
-<p class="abstract">Use badges to show the status of a service.<p>
+Use badges to show the status of a service.
+{: .abstract }

--- a/_components/tables/basic-table-guidance.md
+++ b/_components/tables/basic-table-guidance.md
@@ -1,6 +1,13 @@
+{% assign ID = "tables" %}
+
+{% capture content %}
+- Tables should be used for data, never design.
 - Consider more accessible ways to format content before using a table, such as lists.
 - Avoid tables with multiple header levels and spanned cells.
 - Use `thead`, `tbody` and `tfoot` to improve how browsers display tables. They don't make tables more accessible.
 - Title tables using the <a href="https://www.w3.org/wiki/HTML/Elements/caption" rel="external">`<caption>` element</a> inside the `<table>` element.
 - Row and column headers should be set with the <a href="https://www.w3.org/TR/html401/struct/tables.html#adef-scope" rel="external">`scope` attribute</a>.
 - <a href="https://www.w3.org/WAI/tutorials/tables/" rel="external">W3C has guidance on making tables</a>.
+{% endcapture %}
+
+{% include guidance.liquid  content = content  ID = ID %}

--- a/_components/tables/index.md
+++ b/_components/tables/index.md
@@ -3,15 +3,12 @@ layout: collections/item
 title: Tables
 section: Tables
 sections:
-  - md: Basic table top
+  - headline: Tables
   - code:
     - scss: assets/sass/components/_tables
     - markup: table-examples
   - md: Basic table guidance
-
-  - headline: Building tables
-  - md: Building top
-  - md: Building guidance
 ---
 
-<p class="abstract">Use tables to make data content easier to scan.<p>
+Use tables to make data content easier to scan.
+{: .abstract }


### PR DESCRIPTION
The Components > Tables section had the guidance as a separate h2, see: http://guides.service.gov.au/design-guide/components/tables/index.html#building-tables

Fixed to make this fall within the guidance accordions.

Also fixed a superfluous file from Components > Badges.

## Description

Thanks to @skpandey27 for finding this bug. (:

## Definition of Done

- [x] Code reviewed by one of the core developers